### PR TITLE
Publish major and minor tags too

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,3 +1,3 @@
 FROM scratch
 LABEL org.opencontainers.image.authors="Fake Leaks <fake-leaks@leaktk.org>, Fake Leaks2 <fake-leaks2@leaktk.org>"
-COPY * /
+COPY * /fake-leaks/

--- a/hack/publish-container.sh
+++ b/hack/publish-container.sh
@@ -3,7 +3,14 @@ set -euo pipefail
 
 version="$1"
 
+semver="${version#v}"
+major="v${semver%%.*}"
+minor="${semver#*.}"
+minor="$major.${minor%%.*}"
+
 podman manifest create "fake-leaks:${version}"
+podman manifest create "fake-leaks:${major}"
+podman manifest create "fake-leaks:${minor}"
 
 for arch in aarch64 amd64
 do
@@ -11,6 +18,10 @@ do
   podman push --format v2s2 "quay.io/leaktk/fake-leaks:${version}-${arch}"
   podman pull "quay.io/leaktk/fake-leaks:${version}-${arch}"
   podman manifest add "fake-leaks:${version}" "quay.io/leaktk/fake-leaks:${version}-${arch}"
+  podman manifest add "fake-leaks:${major}" "quay.io/leaktk/fake-leaks:${version}-${arch}"
+  podman manifest add "fake-leaks:${minor}" "quay.io/leaktk/fake-leaks:${version}-${arch}"
 done
 
 podman manifest push   "fake-leaks:${version}" "docker://quay.io/leaktk/fake-leaks:${version}"
+podman manifest push   "fake-leaks:${major}" "docker://quay.io/leaktk/fake-leaks:${major}"
+podman manifest push   "fake-leaks:${minor}" "docker://quay.io/leaktk/fake-leaks:${minor}"


### PR DESCRIPTION
* Moved the fake-leaks to a folder to keep it more organised
* Quay allows tags to be overwritten so v2/v2.0 will point to the latest v2.0.6 when it is for example.